### PR TITLE
Randomly select only from gifs that have not shown yet.

### DIFF
--- a/src/graphql/mutations/present-random-entry.ts
+++ b/src/graphql/mutations/present-random-entry.ts
@@ -48,5 +48,5 @@ export default function usePresentRandomEntry(teamId: number) {
     } else {
       throw new Error('Unable to present random entry');
     }
-  }, [fetch, presentEntry, teamId]);
+  }, []);
 }


### PR DESCRIPTION
A huge change (1 line lol) 
Now the useCallback function is triggered to rerun properly when the presented GIFs get updated, not just upon refresh!

Caique and I looked into how to use the useEffect hook instead of useCallback but I couldn't get it to be triggered every time, so if you have advice about that, let me know :)