### PR TITLE
Add black border for better contrast and visibility for Session host setting

### DIFF
--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -53,7 +53,7 @@ const EditUserRole: React.FC<{
     <p className="text-lg">Session host</p>
     <input
       type="checkbox"
-      className="w-6 h-6 text-black form-checkbox"
+      className="w-6 h-6 text-black form-checkbox border-black"
       checked={checked}
       onChange={onChange}
     />

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -50,8 +50,9 @@ const EditUserRole: React.FC<{
   onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
 }> = ({ checked, onChange }) => (
   <div className="flex items-center justify-between">
-    <p className="text-lg">Session host</p>
+    <label htmlFor="session-host" className="text-lg">Session host</label>
     <input
+      id="session-host"
       type="checkbox"
       className="w-6 h-6 text-black form-checkbox border-black"
       checked={checked}


### PR DESCRIPTION
It took me a Slack question to realize there was a checkbox for Session host setting.

This PR adds a black border around the checkbox to increase contrast and visibility.

It also changes the Session host to be a proper `<label>` for accessibility.

Before:
<img width="555" alt="settings form with bad contrast checkbox" src="https://user-images.githubusercontent.com/1909996/165113895-85498a8d-2625-4441-866d-d069a71fa0b5.png">

After:

<img width="553" alt="settings form with good contrast checkbox" src="https://user-images.githubusercontent.com/1909996/165113910-837fde9a-3496-4db8-be81-410d488d94f5.png">

