### PR TITLE
Adjust team picker formatting for longer names

### DIFF
--- a/src/components/team-picker/styles.module.css
+++ b/src/components/team-picker/styles.module.css
@@ -1,5 +1,5 @@
 .button {
-  @apply flex items-center h-12 pl-6 pr-4 text-lg font-bold text-black border-0 rounded-lg;
+  @apply flex items-center justify-end h-12 pl-6 pr-4 text-lg font-bold text-black border-0 rounded-lg;
 }
 
 .button:hover {
@@ -11,7 +11,7 @@
 }
 
 .listItem {
-  @apply flex items-center h-12 px-6 select-none;
+  @apply flex items-center px-2 py-1 select-none;
 }
 
 .listItem:hover {


### PR DESCRIPTION
At the moment the team picker button get's its width from the name of the currently selected team.
For short selected team names (e.g. Oslo or Berlin), the longer team names in the popover menu that opens when the button is clicked are cut off because the popover is in turn getting its width from the buttons width.

My plan was to change the picker popover such that it automatically grows in width to fit the longest team name.
It appears to me that ReachUI only allows the portal used to contain the popover to have the exact same width as the button that opens it, the width is set in absolute placement.
I couldn't find a way around it.
After fiddling around for a while, I decided to just reformat it a little to at least look not too horrible with the team names we usually use.
1. If we switch off the use of a portal, the popover does adjust correctly, but it is not really a popover any more
2. The documentation shows code that seems to be growing the popover even in portal mode (code example 2 in https://reach.tech/listbox/), but if I copy exactly that code into our settings page, it shows the wrong behaviour again.3. 
3. I did try the newest version of ReachUI without seeing any changes.

If you know a way to get the popover with a width depending on its contents, not the ListboxButton, I'd be more than happy to adjust it.